### PR TITLE
整数から小数点第１位までの小数への変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,15 +5,19 @@ class PostsController < ApplicationController
     @posts = Post.all.includes(:user).order("created_at DESC").page(params[:page]).per(5)
     @post = Post.new
     # 今日の合計カロリー
-    @calorie_sum = Post.where(user_id: current_user.id, created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).sum(:calorie)
-    gon.today_sum = @calorie_sum
-    @standard = Standard.find_by(user_id: current_user.id)
-    @calorie_standard = @standard.calorie
-    gon.standard = @calorie_standard
-    if @calorie_sum >= @calorie_standard
-      @difference = @calorie_sum - @calorie_standard
+    if user_signed_in?
+      @calorie_sum = Post.where(user_id: current_user.id, created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).sum(:calorie)
+      gon.today_sum = @calorie_sum
+      @standard = Standard.find_by(user_id: current_user.id)
+      @calorie_standard = @standard.calorie
+      gon.standard = @calorie_standard
+      if @calorie_sum >= @calorie_standard
+        @difference = @calorie_sum - @calorie_standard
+      else
+        @difference = @calorie_standard - @calorie_sum
+      end
     else
-      @difference = @calorie_standard - @calorie_sum
+      
     end
   end
 

--- a/app/views/devise/registrations/new_standard.html.haml
+++ b/app/views/devise/registrations/new_standard.html.haml
@@ -7,48 +7,48 @@
     体重を入力してください。
     .field
       = f.label :"体重"
-      = f.number_field :weight 
+      = f.number_field :weight, step: '0.1'
       %a kg
   %p
     体脂肪率を入力してください。
     .field
       = f.label :"体脂肪率"
-      = f.number_field :bodyFatPercentage
+      = f.number_field :bodyFatPercentage, step: '0.1'
       %a %
 
   %p
     あなたの除脂肪体重は
     .field
       = f.label :"除脂肪体重"
-      = f.number_field :leanBodyMass
+      = f.number_field :leanBodyMass, step: '0.1'
       %a kgです。
 
   %p
     あなたの１日のカロリー目安は
     .field
       = f.label :"カロリー"
-      = f.number_field :calorie
+      = f.number_field :calorie, step: '0.1'
       %a gです。
 
   %p
     あなたの１日のタンパク質目安は
     .field
       = f.label :"タンパク質"
-      = f.number_field :protein
+      = f.number_field :protein, step: '0.1'
       %a gです。
 
   %p
     あなたの１日の脂質目安は
     .field
       = f.label :"脂質"
-      = f.number_field :fat
+      = f.number_field :fat, step: '0.1'
       %a gです。
 
   %p
     あなたの１日の炭水化物目安は
     .field
       = f.label :"炭水化物"
-      = f.number_field :carbo
+      = f.number_field :carbo, step: '0.1'
       %a gです。
 
   .actions

--- a/app/views/posts/_main.html.haml
+++ b/app/views/posts/_main.html.haml
@@ -1,6 +1,7 @@
 .main
   .section
     .calorie_chart
+    - if user_signed_in?
       .calorie_graph
         %canvas(id="myChart2" width="700" height="100")
         :javascript

--- a/app/views/posts/_main.html.haml
+++ b/app/views/posts/_main.html.haml
@@ -61,13 +61,13 @@
                 %td 
                   = f.text_field :food, placeholder: '例）サラダ'
                 %td 
-                  = f.number_field :calorie, placeholder: '例）200'
+                  = f.number_field :calorie, step: '0.1', placeholder: '例）200'
                 %td 
-                  = f.number_field :protein, placeholder: '例）30'
+                  = f.number_field :protein, step: '0.1', placeholder: '例）30'
                 %td 
-                  = f.number_field :fat, placeholder: '例）20'
+                  = f.number_field :fat, step: '0.1', placeholder: '例）20'
                 %td 
-                  = f.number_field :carbo, placeholder: '例）50'
+                  = f.number_field :carbo, step: '0.1', placeholder: '例）50'
                 %td.icon-plus
                   %i.fa.fa-plus-circle.fa-2x{class: 'plus-button'}
                 %td.icon-minus

--- a/db/migrate/20200821055333_change_data_calorie_to_post.rb
+++ b/db/migrate/20200821055333_change_data_calorie_to_post.rb
@@ -1,0 +1,5 @@
+class ChangeDataCalorieToPost < ActiveRecord::Migration[5.2]
+  def change
+    change_column :posts, :calorie, :float
+  end
+end

--- a/db/migrate/20200821060005_change_data_protein_to_post.rb
+++ b/db/migrate/20200821060005_change_data_protein_to_post.rb
@@ -1,0 +1,5 @@
+class ChangeDataProteinToPost < ActiveRecord::Migration[5.2]
+  def change
+    change_column :posts, :protein, :float
+  end
+end

--- a/db/migrate/20200821060056_change_data_fat_to_post.rb
+++ b/db/migrate/20200821060056_change_data_fat_to_post.rb
@@ -1,0 +1,5 @@
+class ChangeDataFatToPost < ActiveRecord::Migration[5.2]
+  def change
+    change_column :posts, :fat, :float
+  end
+end

--- a/db/migrate/20200821060137_change_data_carbo_to_post.rb
+++ b/db/migrate/20200821060137_change_data_carbo_to_post.rb
@@ -1,0 +1,5 @@
+class ChangeDataCarboToPost < ActiveRecord::Migration[5.2]
+  def change
+    change_column :posts, :carbo, :float
+  end
+end

--- a/db/migrate/20200821061619_change_data_weight_to_standard.rb
+++ b/db/migrate/20200821061619_change_data_weight_to_standard.rb
@@ -1,0 +1,5 @@
+class ChangeDataWeightToStandard < ActiveRecord::Migration[5.2]
+  def change
+    change_column :standards, :weight, :float
+  end
+end

--- a/db/migrate/20200821061739_change_data_calorie_to_standard.rb
+++ b/db/migrate/20200821061739_change_data_calorie_to_standard.rb
@@ -1,0 +1,5 @@
+class ChangeDataCalorieToStandard < ActiveRecord::Migration[5.2]
+  def change
+    change_column :standards, :calorie, :float
+  end
+end

--- a/db/migrate/20200821061807_change_data_fat_to_standard.rb
+++ b/db/migrate/20200821061807_change_data_fat_to_standard.rb
@@ -1,0 +1,5 @@
+class ChangeDataFatToStandard < ActiveRecord::Migration[5.2]
+  def change
+    change_column :standards, :fat, :float
+  end
+end

--- a/db/migrate/20200821061831_change_data_carbo_to_standard.rb
+++ b/db/migrate/20200821061831_change_data_carbo_to_standard.rb
@@ -1,0 +1,5 @@
+class ChangeDataCarboToStandard < ActiveRecord::Migration[5.2]
+  def change
+    change_column :standards, :carbo, :float
+  end
+end

--- a/db/migrate/20200821061914_change_data_body_fat_percentage_to_standard.rb
+++ b/db/migrate/20200821061914_change_data_body_fat_percentage_to_standard.rb
@@ -1,0 +1,5 @@
+class ChangeDataBodyFatPercentageToStandard < ActiveRecord::Migration[5.2]
+  def change
+    change_column :standards, :bodyFatPercentage, :float
+  end
+end

--- a/db/migrate/20200821062015_change_data_lean_body_mass_to_standard.rb
+++ b/db/migrate/20200821062015_change_data_lean_body_mass_to_standard.rb
@@ -1,0 +1,5 @@
+class ChangeDataLeanBodyMassToStandard < ActiveRecord::Migration[5.2]
+  def change
+    change_column :standards, :leanBodyMass, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_21_055333) do
+ActiveRecord::Schema.define(version: 2020_08_21_060137) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "comment", null: false
@@ -41,9 +41,9 @@ ActiveRecord::Schema.define(version: 2020_08_21_055333) do
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "food", null: false
     t.float "calorie", null: false
-    t.integer "protein"
-    t.integer "fat"
-    t.integer "carbo"
+    t.float "protein"
+    t.float "fat"
+    t.float "carbo"
     t.text "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_16_120835) do
+ActiveRecord::Schema.define(version: 2020_08_21_055333) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "comment", null: false
@@ -20,14 +20,6 @@ ActiveRecord::Schema.define(version: 2020_08_16_120835) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
-  end
-
-  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "image"
-    t.bigint "post_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["post_id"], name: "index_images_on_post_id"
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -48,7 +40,7 @@ ActiveRecord::Schema.define(version: 2020_08_16_120835) do
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "food", null: false
-    t.integer "calorie", null: false
+    t.float "calorie", null: false
     t.integer "protein"
     t.integer "fat"
     t.integer "carbo"
@@ -93,11 +85,11 @@ ActiveRecord::Schema.define(version: 2020_08_16_120835) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", default: "0", null: false
+    t.string "image"
   end
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
-  add_foreign_key "images", "posts"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_21_060137) do
+ActiveRecord::Schema.define(version: 2020_08_21_062015) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "comment", null: false
@@ -63,16 +63,16 @@ ActiveRecord::Schema.define(version: 2020_08_21_060137) do
   end
 
   create_table "standards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "weight"
-    t.integer "calorie"
+    t.float "weight"
+    t.float "calorie"
     t.integer "protein"
-    t.integer "fat"
-    t.integer "carbo"
+    t.float "fat"
+    t.float "carbo"
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "bodyFatPercentage"
-    t.integer "leanBodyMass"
+    t.float "bodyFatPercentage"
+    t.float "leanBodyMass"
     t.index ["user_id"], name: "index_standards_on_user_id"
   end
 


### PR DESCRIPTION
# What
カロリー値やPFC値を整数ではなく小数で入力可能にした。

# Why
ほとんどの食品のPFC値は小数で表示されているから。