### PR TITLE
postsテーブルのfoodカラムのデータ型変更

### DIFF
--- a/db/migrate/20201010214523_change_data_type_to_posts.rb
+++ b/db/migrate/20201010214523_change_data_type_to_posts.rb
@@ -1,0 +1,5 @@
+class ChangeDataTypeToPosts < ActiveRecord::Migration[5.2]
+  def change
+    change_column :posts, :food, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_125014) do
+ActiveRecord::Schema.define(version: 2020_10_10_214523) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "comment"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2020_09_23_125014) do
   end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "food", null: false
+    t.string "food", null: false
     t.float "calorie", null: false
     t.float "protein"
     t.float "fat"


### PR DESCRIPTION
# What
postsテーブルのfoodカラムのデータ型をtextからstringに変更した。

# Why
コンテナでrails testすると「postsテーブルのfoodカラムにデフォルト値が設定されてない」とエラーで怒られた。
text型だとデフォルト値の設定ができないため。