### PR TITLE
database.ymlの変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@
 # And be sure to use new-style password hashing:
 #   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
 #
-default: &default
+default:
   adapter: mysql2
   encoding: utf8
   pool: 5
@@ -19,15 +19,26 @@ default: &default
   #socket: /tmp/mysql.sock
 
 development:
-  <<: *default
+  adapter: mysql2
+  encoding: utf8
   database: pfc-master_development
+  pool: 5
+  username: root
+  password: password
+  host: localhost
+
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
+  adapter: mysql2
+  encoding: utf8
   database: pfc-master_test
+  pool: 5
+  username: root
+  password: password
+  host: localhost
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -49,11 +60,11 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 production:
-  <<: *default
-  # adapter: mysql2
-  # encoding: utf8
-  # pool: 5
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
   database: pfc-master_production
   username: root
   password: password
+  host: localhost
   # socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
# What
database.ymlの変更した。
具体的には、development, test, productionの3つの環境の場合わけの共通部分をdefaultで括っていたのをやめた。
defaultのhost: dbこれはdocker用に残しつつ、その他の3つの環境はdefaultからの継承ではなくそれぞれそのまま書くように変更した。

# Why
Dockerのコンテナ環境でのサーバー起動と本番環境からの起動を両立させるため。
