### PR TITLE
コメントで顔文字を使えるようにした

### DIFF
--- a/app/views/comments/create.json.jbuilder
+++ b/app/views/comments/create.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.user_name @comment.user.name
+json.user_name @comment.user.username
 json.user_id @comment.user.id
 json.created_at @comment.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.comment @comment.comment

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -39,7 +39,7 @@
               .comment
                 %time(datetime="#{comment.created_at}")= time_ago_in_words(comment.created_at)+"前"
                 .commentUser
-                  = comment.user.name
+                  = comment.user.username
                 .commentContent
                   = comment.comment
       %ul.comment-fa


### PR DESCRIPTION
顔文字だとユーザー同士でより感情的なやりとりができるようになり、互いのモチベーション維持につながると考えたため。